### PR TITLE
Correction de la condition d'exécution des tâches

### DIFF
--- a/api/src/Scheduler/Task.php
+++ b/api/src/Scheduler/Task.php
@@ -68,7 +68,7 @@ abstract class Task
             return false;
         }
 
-        return $this->cronExpression->isDue();
+        return $this->cronExpression->isDue() && $this->truthSetting;
     }
 
     abstract public function execute(): void;


### PR DESCRIPTION
La condition d'exécution des tâches (`Task::when()`) n'était pas vérifiée, ce qui entraînait une exécution même quand cette condition était fausse.  
Ceci est corrigé.