### PR TITLE
Affichage dates escales et tri des rapports manutention

### DIFF
--- a/api/src/DTO/CallWithoutReportDTO.php
+++ b/api/src/DTO/CallWithoutReportDTO.php
@@ -10,6 +10,8 @@ namespace App\DTO;
  * @phpstan-type CallWithoutReport array{
  *                                   id: int,
  *                                   shipName: string,
+ *                                   startDate?: string,
+ *                                   endDate?: string,
  *                                 }
  */
 final readonly class CallWithoutReportDTO
@@ -25,6 +27,16 @@ final readonly class CallWithoutReportDTO
     public string $shipName;
 
     /**
+     * Start date of the call.
+     */
+    public ?string $startDate;
+
+    /**
+     * End date of the call.
+     */
+    public ?string $endDate;
+
+    /**
      * Constructor.
      *
      * @phpstan-param CallWithoutReport $rawData
@@ -33,5 +45,7 @@ final readonly class CallWithoutReportDTO
     {
         $this->id = $rawData['id'];
         $this->shipName = $rawData['shipName'];
+        $this->startDate = $rawData['startDate'] ?? null;
+        $this->endDate = $rawData['endDate'] ?? null;
     }
 }

--- a/api/src/DTO/IgnoredCallDTO.php
+++ b/api/src/DTO/IgnoredCallDTO.php
@@ -10,6 +10,8 @@ namespace App\DTO;
  * @phpstan-type IgnoredCall array{
  *                             id: int,
  *                             shipName: string,
+ *                             startDate?: string,
+ *                             endDate?: string,
  *                           }
  */
 final readonly class IgnoredCallDTO
@@ -25,6 +27,16 @@ final readonly class IgnoredCallDTO
     public string $shipName;
 
     /**
+     * Start date of the call.
+     */
+    public ?string $startDate;
+
+    /**
+     * End date of the call.
+     */
+    public ?string $endDate;
+
+    /**
      * Constructor.
      *
      * @phpstan-param IgnoredCall $rawData
@@ -33,5 +45,7 @@ final readonly class IgnoredCallDTO
     {
         $this->id = $rawData['id'];
         $this->shipName = $rawData['shipName'];
+        $this->startDate = $rawData['startDate'] ?? null;
+        $this->endDate = $rawData['endDate'] ?? null;
     }
 }

--- a/html/src/pages/manutention/rapports-navires/components/idComponents/src/CallSelectionModal.svelte
+++ b/html/src/pages/manutention/rapports-navires/components/idComponents/src/CallSelectionModal.svelte
@@ -7,7 +7,7 @@
 
   import { LucideButton } from "@app/components";
 
-  import { fetcher } from "@app/utils";
+  import { fetcher, DateUtils } from "@app/utils";
 
   import { consignationEscales } from "@app/stores";
 
@@ -20,6 +20,8 @@
   type CallSummary = {
     id: number;
     shipName: string;
+    startDate: string;
+    endDate: string;
   };
 
   let callList: CallSummary[] = null;
@@ -150,9 +152,16 @@
   <!-- Escales disponibles -->
   {#if callList && !callListError}
     {#each callList as call}
-      <div>
-        <Button on:click={() => handleCallSelection(call.id)}>
-          {call.shipName}
+      <div class="flex items-center justify-center gap-2 mb-2">
+        <Button class="flex-col" on:click={() => handleCallSelection(call.id)}>
+          <span>{call.shipName}</span>
+          <span class="text-xs"
+            >{call.startDate
+              ? new DateUtils(call.startDate).format().short
+              : "?"} - {call.endDate
+              ? new DateUtils(call.endDate).format().short
+              : "?"}</span
+          >
         </Button>
         <LucideButton
           icon={EyeOffIcon}
@@ -179,8 +188,17 @@
       <AccordionItem>
         <span slot="header">Escales ignorées</span>
         {#each ignoredCalls as call}
-          <div>
-            {call.shipName}
+          <div class="flex items-center justify-center gap-2 mb-2">
+            <div class="flex flex-col">
+              <span>{call.shipName}</span>
+              <span class="text-xs"
+                >{call.startDate
+                  ? new DateUtils(call.startDate).format().short
+                  : "?"} - {call.endDate
+                  ? new DateUtils(call.endDate).format().short
+                  : "?"}</span
+              >
+            </div>
             <LucideButton
               icon={EyeIcon}
               on:click={() => unignoreCall(call)}


### PR DESCRIPTION
Afficher les dates dans la sélection des escales pour créer un rapport navire.

Tri des rapports manutention par date.