### PR TITLE
Prevent deletion of bulk products and qualities with existing appointments

### DIFF
--- a/api/public/index.php
+++ b/api/public/index.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 require_once __DIR__ . "/../bootstrap.php";
 
 use App\Controller\Admin\UserAccountController;
+use App\Controller\Bulk\AppointmentCountController as BulkProductAppointmentCountController;
 use App\Controller\Bulk\BulkAppointmentController;
 use App\Controller\Bulk\BulkDispatchController;
 use App\Controller\Bulk\BulkProductController;
@@ -41,7 +42,7 @@ use App\Controller\Stevedoring\SubcontractorsDataController;
 use App\Controller\Stevedoring\TempWorkDispatchForDateController;
 use App\Controller\Stevedoring\TempWorkHoursController;
 use App\Controller\Stevedoring\TempWorkHoursReportController;
-use App\Controller\ThirdParty\AppointmentCountController;
+use App\Controller\ThirdParty\AppointmentCountController as ThirdPartyAppointmentCountController;
 use App\Controller\ThirdParty\ThirdPartyController;
 use App\Controller\Timber\TimberAppointmentController;
 use App\Controller\Timber\TimberDeliveryNoteController;
@@ -87,6 +88,7 @@ $routes = [
     // Vrac
     ["/vrac/rdvs/[i:id]?", BulkAppointmentController::class],
     ["/vrac/produits/[i:id]?", BulkProductController::class],
+    ["/vrac/produits/[i:id]/nombre_rdv", BulkProductAppointmentCountController::class],
     ["/vrac/dispatch", BulkDispatchController::class],
 
     // Consignation
@@ -133,7 +135,7 @@ $routes = [
 
     // Tiers
     ["/tiers/[i:id]?", ThirdPartyController::class],
-    ["/tiers/[i:id]/nombre_rdv", AppointmentCountController::class],
+    ["/tiers/[i:id]/nombre_rdv", ThirdPartyAppointmentCountController::class],
 
     // Admin
     ["/admin/users/[a:uid]?", UserAccountController::class],

--- a/api/src/Controller/Bulk/AppointmentCountController.php
+++ b/api/src/Controller/Bulk/AppointmentCountController.php
@@ -1,0 +1,73 @@
+<?php
+
+// Path: api/src/Controller/Bulk/AppointmentCountController.php
+
+declare(strict_types=1);
+
+namespace App\Controller\Bulk;
+
+use App\Controller\Controller;
+use App\Core\Exceptions\Client\NotFoundException;
+use App\Core\HTTP\ETag;
+use App\Core\HTTP\HTTPResponse;
+use App\Service\BulkService;
+
+final class AppointmentCountController extends Controller
+{
+    private BulkService $service;
+
+    public function __construct(
+        private int $id,
+    ) {
+        parent::__construct();
+        $this->service = new BulkService();
+        $this->processRequest();
+    }
+
+    private function processRequest(): void
+    {
+        switch ($this->request->getMethod()) {
+            case 'OPTIONS':
+                $this->response
+                    ->setCode(HTTPResponse::HTTP_NO_CONTENT_204)
+                    ->addHeader("Allow", $this->supportedMethods);
+                break;
+
+            case 'HEAD':
+            case 'GET':
+                $this->read($this->id);
+                break;
+
+            default:
+                $this->response
+                    ->setCode(HTTPResponse::HTTP_METHOD_NOT_ALLOWED_405)
+                    ->addHeader("Allow", $this->supportedMethods);
+                break;
+        }
+    }
+
+    /**
+     * Retrieves the number of appointments for a bulk product.
+     * 
+     * @param int $id The id of the bulk product to retrieve.
+     */
+    private function read(int $id): void
+    {
+        if (!$this->service->productExists($id)) {
+            throw new NotFoundException("Le produit n'existe pas.");
+        }
+
+        $appointmentCount = $this->service->getAppointmentCountForProductId($id);
+
+        $etag = ETag::get($appointmentCount);
+
+        if ($this->request->etag === $etag) {
+            $this->response->setCode(HTTPResponse::HTTP_NOT_MODIFIED_304);
+            return;
+        }
+
+        $this->response
+            ->addHeader("ETag", $etag)
+            ->setJSON($appointmentCount);
+    }
+}

--- a/api/src/DTO/BulkProductAppointmentCountDTO.php
+++ b/api/src/DTO/BulkProductAppointmentCountDTO.php
@@ -1,0 +1,53 @@
+<?php
+
+// Path: api/src/DTO/BulkProductAppointmentCountDTO.php
+
+declare(strict_types=1);
+
+namespace App\DTO;
+
+/**
+ * @phpstan-type BulkProductAppointmentCountArray = array{
+ *                                                    'id': 'total'|int,
+ *                                                    'count': int
+ *                                                  }
+ */
+final class BulkProductAppointmentCountDTO implements \JsonSerializable
+{
+    /**
+     * The number of appointments for the bulk product.
+     * 
+     * @var array<'total'|int, int>
+     */
+    public array $appointmentCount;
+
+    public int $total {
+        get => $this->appointmentCount['total'] ?? 0;
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param BulkProductAppointmentCountArray[] $rawData
+     */
+    public function __construct(array $rawData)
+    {
+        $this->appointmentCount = [];
+
+        foreach ($rawData as ['id' => $id, 'count' => $count]) {
+            if ($id) {
+                $this->appointmentCount[$id] = $count;
+            }
+        }
+    }
+
+    public function forQuality(int $id): int
+    {
+        return $this->appointmentCount[$id] ?? 0;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return $this->appointmentCount;
+    }
+}

--- a/api/src/Service/BulkService.php
+++ b/api/src/Service/BulkService.php
@@ -12,6 +12,7 @@ use App\Core\Exceptions\Client\NotFoundException;
 use App\Core\Exceptions\Server\DB\DBException;
 use App\Core\HTTP\HTTPRequestBody;
 use App\DTO\BulkDispatchStatsDTO;
+use App\DTO\BulkProductAppointmentCountDTO;
 use App\DTO\Filter\BulkDispatchStatsFilterDTO;
 use App\DTO\Filter\BulkFilterDTO;
 use App\Entity\Bulk\BulkAppointment;
@@ -390,6 +391,16 @@ final class BulkService
         return $this->productRepository->deleteProduct($id);
     }
 
+    /**
+     * Retrieves the number of appointments for a third party or all third parties.
+     * 
+     * @param int $id ID of the third party to retrieve.
+     */
+    public function getAppointmentCountForProductId(int $id): BulkProductAppointmentCountDTO
+    {
+        return $this->productRepository->fetchAppointmentCountForId($id);
+    }
+
 
     // =========
     // Qualities
@@ -456,6 +467,8 @@ final class BulkService
 
         return $this->productRepository->fetchQuality($id);
     }
+
+
 
     // ========
     // Dispatch

--- a/html/src/lib/components/src/LucideButton.svelte
+++ b/html/src/lib/components/src/LucideButton.svelte
@@ -232,9 +232,10 @@
   button.disabled {
     cursor: not-allowed;
     color: var(--default-color);
+    filter: brightness(1.2);
 
-    &:is(:hover, :focus) {
-      color: var(--default-color);
+    &:is(:hover)::before {
+      opacity: 0;
     }
   }
 </style>

--- a/html/src/pages/vrac/produits/components/src/LigneQualite.svelte
+++ b/html/src/pages/vrac/produits/components/src/LigneQualite.svelte
@@ -7,6 +7,7 @@
 
   export let qualite: QualiteVrac;
   export let supprimerQualite: (qualite: QualiteVrac) => void;
+  export let nombreRdv = 0;
 
   $: isNew = qualite.id === null;
 </script>
@@ -39,7 +40,10 @@
   <div class="ms-3 self-center">
     <LucideButton
       preset="delete"
-      title="Supprimer la qualité"
+      title={nombreRdv > 0
+        ? `La qualité est concernée par ${nombreRdv} rdv. Impossible de la supprimer.`
+        : "Supprimer la qualité"}
+      disabled={nombreRdv > 0}
       on:click={() => supprimerQualite(qualite)}
     />
   </div>

--- a/html/src/pages/vrac/produits/index.svelte
+++ b/html/src/pages/vrac/produits/index.svelte
@@ -44,9 +44,13 @@
       $vracProduits?.get(id) || vracProduits.getTemplate()
     );
 
-    nombreRdv = await fetcher<NombreRdv>(
-      `/api/vrac/produits/${id}/nombre_rdv`
-    ).catch(() => null);
+    if (id) {
+      nombreRdv = await fetcher<NombreRdv>(
+        `/api/vrac/produits/${id}/nombre_rdv`
+      ).catch(() => null);
+    } else {
+      nombreRdv = null;
+    }
   }
 
   /**
@@ -71,8 +75,7 @@
     if (qualiteASupprimer.id !== null) {
       Notiflix.Confirm.show(
         "Suppression produit",
-        `Voulez-vous vraiment supprimer la qualité <strong>${qualiteASupprimer.nom}</strong> ?<br />` +
-          `Ceci supprimera les RDV associés.`,
+        `Voulez-vous vraiment supprimer la qualité <strong>${qualiteASupprimer.nom}</strong> ?`,
         "Supprimer",
         "Annuler",
         _supprimerQualite,
@@ -172,8 +175,7 @@
 
     Notiflix.Confirm.show(
       "Suppression produit",
-      `Voulez-vous vraiment supprimer le produit <b>${produit.nom}</b> ?<br />` +
-        `Ceci supprimera les RDV associés.`,
+      `Voulez-vous vraiment supprimer le produit <b>${produit.nom}</b> ?`,
       "Supprimer",
       "Annuler",
       async function () {
@@ -277,7 +279,7 @@
               <LigneQualite
                 {qualite}
                 {supprimerQualite}
-                nombreRdv={nombreRdv[qualite.id] || 0}
+                nombreRdv={nombreRdv?.[qualite.id] || 0}
               />
             {/each}
           </ul>


### PR DESCRIPTION
Enhance the application to prevent the deletion of bulk products and qualities if they are associated with any appointments. Introduce a new AppointmentCountController to manage appointment count requests and update the user interface to reflect these restrictions. Modify styles for disabled buttons and handle cases where no product is selected.

Fixes #41