### PR TITLE
Ajout des contacts associés aux tiers

### DIFF
--- a/api/public/index.php
+++ b/api/public/index.php
@@ -44,6 +44,7 @@ use App\Controller\Stevedoring\TempWorkHoursController;
 use App\Controller\Stevedoring\TempWorkHoursReportController;
 use App\Controller\ThirdParty\AppointmentCountController as ThirdPartyAppointmentCountController;
 use App\Controller\ThirdParty\ThirdPartyController;
+use App\Controller\ThirdParty\ThirdPartyContactController;
 use App\Controller\Timber\TimberAppointmentController;
 use App\Controller\Timber\TimberDeliveryNoteController;
 use App\Controller\Timber\TimberRegistryController;
@@ -136,6 +137,7 @@ $routes = [
     // Tiers
     ["/tiers/[i:id]?", ThirdPartyController::class],
     ["/tiers/[i:id]/nombre_rdv", ThirdPartyAppointmentCountController::class],
+    ["/tiers/[i:id]/contacts", ThirdPartyContactController::class],
 
     // Admin
     ["/admin/users/[a:uid]?", UserAccountController::class],

--- a/api/src/Controller/ThirdParty/ThirdPartyContactController.php
+++ b/api/src/Controller/ThirdParty/ThirdPartyContactController.php
@@ -1,0 +1,71 @@
+<?php
+
+// Path: api/src/Controller/ThirdParty/ThirdPartyContactController.php
+
+declare(strict_types=1);
+
+namespace App\Controller\ThirdParty;
+
+use App\Controller\Controller;
+use App\Core\Exceptions\Client\NotFoundException;
+use App\Core\HTTP\ETag;
+use App\Core\HTTP\HTTPResponse;
+use App\Service\ThirdPartyService;
+
+final class ThirdPartyContactController extends Controller
+{
+    private ThirdPartyService $thirdPartyService;
+
+    public function __construct(
+        private int $id,
+    ) {
+        parent::__construct("OPTIONS, HEAD, GET");
+        $this->thirdPartyService = new ThirdPartyService();
+        $this->processRequest();
+    }
+
+    private function processRequest(): void
+    {
+        switch ($this->request->getMethod()) {
+            case 'OPTIONS':
+                $this->response
+                    ->setCode(HTTPResponse::HTTP_NO_CONTENT_204)
+                    ->addHeader("Allow", $this->supportedMethods);
+                break;
+
+            case 'HEAD':
+            case 'GET':
+                $this->read($this->id);
+                break;
+
+            default:
+                $this->response
+                    ->setCode(HTTPResponse::HTTP_METHOD_NOT_ALLOWED_405)
+                    ->addHeader("Allow", $this->supportedMethods);
+                break;
+        }
+    }
+
+    /**
+     * Retrieves all contacts for a third party.
+     */
+    public function read(int $id): void
+    {
+        if (!$this->thirdPartyService->thirdPartyExists($id)) {
+            throw new NotFoundException("Ce tiers n'existe pas.");
+        }
+
+        $thirdPartyContacts = $this->thirdPartyService->getThirdPartyContacts($id);
+
+        $etag = ETag::get($thirdPartyContacts);
+
+        if ($this->request->etag === $etag) {
+            $this->response->setCode(HTTPResponse::HTTP_NOT_MODIFIED_304);
+            return;
+        }
+
+        $this->response
+            ->addHeader("ETag", $etag)
+            ->setJSON($thirdPartyContacts);
+    }
+}

--- a/api/src/DTO/PDF/BulkPDF.php
+++ b/api/src/DTO/PDF/BulkPDF.php
@@ -11,7 +11,7 @@ use App\Core\Component\Collection;
 use App\Core\Component\DateUtils;
 use App\Entity\Bulk\BulkAppointment;
 use App\Entity\Config\AgencyDepartment;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 final class BulkPDF extends PlanningPDF
 {

--- a/api/src/DTO/PDF/PlanningPDF.php
+++ b/api/src/DTO/PDF/PlanningPDF.php
@@ -8,7 +8,7 @@ namespace App\DTO\PDF;
 
 use App\Core\Exceptions\Server\ServerException;
 use App\Entity\Config\AgencyDepartment;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 define("_SYSTEM_TTFONTS", UNIFONTS . "/");
 

--- a/api/src/DTO/PDF/TimberPDF.php
+++ b/api/src/DTO/PDF/TimberPDF.php
@@ -10,7 +10,7 @@ use App\Core\Component\Collection;
 use App\Core\Component\DateUtils;
 use App\Entity\Timber\TimberAppointment;
 use App\Entity\Config\AgencyDepartment;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-type TimberPdfAppointments array{

--- a/api/src/Entity/Bulk/BulkAppointment.php
+++ b/api/src/Entity/Bulk/BulkAppointment.php
@@ -14,7 +14,7 @@ use App\Core\Validation\Constraints\PositiveOrNullNumber;
 use App\Core\Validation\Constraints\Required;
 use App\Core\Validation\ValidationResult;
 use App\Entity\AbstractEntity;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-type BulkAppointmentArray array{

--- a/api/src/Entity/Chartering/Charter.php
+++ b/api/src/Entity/Chartering/Charter.php
@@ -12,7 +12,7 @@ use App\Core\Component\Collection;
 use App\Core\Component\DateUtils;
 use App\Core\Traits\IdentifierTrait;
 use App\Entity\AbstractEntity;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-type CharterArray array{

--- a/api/src/Entity/Config/PdfConfig.php
+++ b/api/src/Entity/Config/PdfConfig.php
@@ -10,7 +10,7 @@ use App\Core\Validation\Constraints\Required;
 use App\Core\Traits\IdentifierTrait;
 use App\Core\Traits\ModuleTrait;
 use App\Entity\AbstractEntity;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * /**

--- a/api/src/Entity/Config/TimberQuickAppointmentAdd.php
+++ b/api/src/Entity/Config/TimberQuickAppointmentAdd.php
@@ -8,7 +8,7 @@ namespace App\Entity\Config;
 
 use App\Core\Validation\Constraints\Required;
 use App\Core\Component\Module;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-type TimberQuickAppointmentAddArray array{

--- a/api/src/Entity/Shipping/ShippingCall.php
+++ b/api/src/Entity/Shipping/ShippingCall.php
@@ -13,7 +13,7 @@ use App\Core\Traits\IdentifierTrait;
 use App\Entity\AbstractEntity;
 use App\Entity\Port;
 use App\Entity\Stevedoring\ShipReport;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-import-type ShippingCallCargoArray from ShippingCallCargo

--- a/api/src/Entity/ThirdParty/ThirdParty.php
+++ b/api/src/Entity/ThirdParty/ThirdParty.php
@@ -89,6 +89,19 @@ final class ThirdParty extends AbstractEntity
 
     public int $appointmentCount = 0;
 
+    /** @var ThirdPartyContact[] $contacts */
+    public array $contacts = [] {
+        set {
+            $this->contacts = \array_map(
+                function ($contact) {
+                    $contact->thirdParty = $this;
+                    return $contact;
+                },
+                $value
+            );
+        }
+    }
+
     /**
      * @param ArrayHandler|ThirdPartyArray|null $data 
      */
@@ -164,6 +177,7 @@ final class ThirdParty extends AbstractEntity
             'logo' => $this->logoUrl,
             'actif' => $this->isActive,
             'nombre_rdv' => $this->appointmentCount,
+            'contacts' => \array_map(fn($contact) => $contact->toArray(), $this->contacts),
         ];
     }
 }

--- a/api/src/Entity/ThirdParty/ThirdParty.php
+++ b/api/src/Entity/ThirdParty/ThirdParty.php
@@ -1,15 +1,17 @@
 <?php
 
-// Path: api/src/Entity/ThirdParty.php
+// Path: api/src/Entity/ThirdParty/ThirdParty.php
 
 declare(strict_types=1);
 
-namespace App\Entity;
+namespace App\Entity\ThirdParty;
 
 use App\Core\Array\ArrayHandler;
 use App\Core\Array\Environment;
 use App\Core\Traits\IdentifierTrait;
 use App\Core\Validation\Constraints\Required;
+use App\Entity\AbstractEntity;
+use App\Entity\Country;
 
 /**
  * @phpstan-type ThirdPartyArray array{
@@ -146,22 +148,22 @@ final class ThirdParty extends AbstractEntity
     public function toArray(): array
     {
         return [
-            "id" => $this->id,
-            "nom_court" => $this->shortName,
-            "nom_complet" => $this->fullName,
-            "adresse_ligne_1" => $this->addressLine1,
-            "adresse_ligne_2" => $this->addressLine2,
-            "cp" => $this->postCode,
-            "ville" => $this->city,
-            "pays" => $this->country?->iso,
-            "telephone" => $this->phone,
-            "commentaire" => $this->comments,
-            "roles" => $this->roles,
-            "non_modifiable" => $this->isNonEditable,
-            "lie_agence" => $this->isAgency,
-            "logo" => $this->logoUrl,
-            "actif" => $this->isActive,
-            "nombre_rdv" => $this->appointmentCount,
+            'id' => $this->id,
+            'nom_court' => $this->shortName,
+            'nom_complet' => $this->fullName,
+            'adresse_ligne_1' => $this->addressLine1,
+            'adresse_ligne_2' => $this->addressLine2,
+            'cp' => $this->postCode,
+            'ville' => $this->city,
+            'pays' => $this->country?->iso,
+            'telephone' => $this->phone,
+            'commentaire' => $this->comments,
+            'roles' => $this->roles,
+            'non_modifiable' => $this->isNonEditable,
+            'lie_agence' => $this->isAgency,
+            'logo' => $this->logoUrl,
+            'actif' => $this->isActive,
+            'nombre_rdv' => $this->appointmentCount,
         ];
     }
 }

--- a/api/src/Entity/ThirdParty/ThirdPartyContact.php
+++ b/api/src/Entity/ThirdParty/ThirdPartyContact.php
@@ -1,0 +1,52 @@
+<?php
+
+// Path: api/src/Entity/ThirdParty/ThirdPartyContact.php
+
+declare(strict_types=1);
+
+namespace App\Entity\ThirdParty;
+
+use App\Core\Traits\IdentifierTrait;
+use App\Entity\AbstractEntity;
+use App\Core\Validation\Constraints\Required;
+
+/**
+ * @phpstan-type ThirdPartyContactArray array{
+ *                                        id: int,
+ *                                        nom: string,
+ *                                        telephone: string,
+ *                                        email: string,
+ *                                        role: string,
+ *                                        commentaire: string,
+ *                                      }
+ */
+class ThirdPartyContact extends AbstractEntity
+{
+    use IdentifierTrait;
+
+    public ?ThirdParty $thirdParty = null;
+
+    #[Required("Le nom du contact est obligatoire.")]
+    public string $name = '';
+
+    public string $email = '';
+
+    public string $phone = '';
+
+    public string $position = '';
+
+    public string $comments = '';
+
+    #[\Override]
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'nom' => $this->name,
+            'telephone' => $this->phone,
+            'email' => $this->email,
+            'role' => $this->position,
+            'commentaire' => $this->comments,
+        ];
+    }
+}

--- a/api/src/Entity/ThirdParty/ThirdPartyContact.php
+++ b/api/src/Entity/ThirdParty/ThirdPartyContact.php
@@ -13,10 +13,11 @@ use App\Core\Validation\Constraints\Required;
 /**
  * @phpstan-type ThirdPartyContactArray array{
  *                                        id: int,
+ *                                        tiers: int,
  *                                        nom: string,
  *                                        telephone: string,
  *                                        email: string,
- *                                        role: string,
+ *                                        fonction: string,
  *                                        commentaire: string,
  *                                      }
  */
@@ -45,7 +46,7 @@ class ThirdPartyContact extends AbstractEntity
             'nom' => $this->name,
             'telephone' => $this->phone,
             'email' => $this->email,
-            'role' => $this->position,
+            'fonction' => $this->position,
             'commentaire' => $this->comments,
         ];
     }

--- a/api/src/Entity/Timber/TimberAppointment.php
+++ b/api/src/Entity/Timber/TimberAppointment.php
@@ -12,7 +12,7 @@ use App\Core\Exceptions\Client\ValidationException;
 use App\Core\Traits\IdentifierTrait;
 use App\Core\Validation\ValidationResult;
 use App\Entity\AbstractEntity;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 
 /**
  * @phpstan-type TimberAppointmentArray array{

--- a/api/src/Repository/BulkAppointmentRepository.php
+++ b/api/src/Repository/BulkAppointmentRepository.php
@@ -14,7 +14,7 @@ use App\DTO\Filter\BulkDispatchStatsFilterDTO;
 use App\DTO\Filter\BulkFilterDTO;
 use App\Entity\Bulk\BulkAppointment;
 use App\Entity\Bulk\BulkDispatchItem;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Service\BulkService;
 
 /**

--- a/api/src/Repository/ThirdPartyRepository.php
+++ b/api/src/Repository/ThirdPartyRepository.php
@@ -9,11 +9,11 @@ namespace App\Repository;
 use App\Core\Component\Collection;
 use App\Core\Exceptions\Client\ClientException;
 use App\Core\Exceptions\Server\DB\DBException;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Service\ThirdPartyService;
 
 /**
- * @phpstan-import-type ThirdPartyArray from \App\Entity\ThirdParty
+ * @phpstan-import-type ThirdPartyArray from \App\Entity\ThirdParty\ThirdParty
  */
 final class ThirdPartyRepository extends Repository
 {

--- a/api/src/Repository/TimberAppointmentRepository.php
+++ b/api/src/Repository/TimberAppointmentRepository.php
@@ -13,7 +13,7 @@ use App\DTO\SupplierWithUniqueDeliveryNoteNumber;
 use App\DTO\TimberRegistryEntryDTO;
 use App\DTO\TimberStatsDTO;
 use App\DTO\TimberTransportSuggestionsDTO;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Entity\Timber\TimberAppointment;
 use App\Entity\Timber\TimberDispatchItem;
 use App\Service\TimberService;

--- a/api/src/Service/BulkService.php
+++ b/api/src/Service/BulkService.php
@@ -19,7 +19,7 @@ use App\Entity\Bulk\BulkAppointment;
 use App\Entity\Bulk\BulkDispatchItem;
 use App\Entity\Bulk\BulkProduct;
 use App\Entity\Bulk\BulkQuality;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Repository\BulkAppointmentRepository;
 use App\Repository\BulkProductRepository;
 

--- a/api/src/Service/PdfConfigService.php
+++ b/api/src/Service/PdfConfigService.php
@@ -19,7 +19,7 @@ use App\DTO\PDF\PlanningPDF;
 use App\DTO\PDF\TimberPDF;
 use App\Entity\Config\AgencyDepartment;
 use App\Entity\Config\PdfConfig;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Repository\PdfConfigRepository;
 use PHPMailer\PHPMailer\Exception as PHPMailerException;
 

--- a/api/src/Service/ThirdPartyService.php
+++ b/api/src/Service/ThirdPartyService.php
@@ -11,11 +11,11 @@ use App\Core\Component\Collection;
 use App\Core\Exceptions\Server\ServerException;
 use App\Core\HTTP\HTTPRequestBody;
 use App\Core\Logger\ErrorLogger;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Repository\ThirdPartyRepository;
 
 /**
- * @phpstan-import-type ThirdPartyArray from \App\Entity\ThirdParty
+ * @phpstan-import-type ThirdPartyArray from \App\Entity\ThirdParty\ThirdParty
  */
 final class ThirdPartyService
 {
@@ -31,9 +31,7 @@ final class ThirdPartyService
     /**
      * Creates a ThirdParty object from raw data.
      * 
-     * @param ThirdPartyArray $rawData 
-     * 
-     * @return ThirdParty 
+     * @param ThirdPartyArray $rawData Raw data from the database.
      */
     public function makeThirdPartyFromDatabase(array $rawData): ThirdParty
     {
@@ -55,9 +53,7 @@ final class ThirdPartyService
     /**
      * Creates a ThirdParty object from form data.
      * 
-     * @param HTTPRequestBody $requestBody 
-     * 
-     * @return ThirdParty 
+     * @param HTTPRequestBody $requestBody
      */
     public function makeThirdPartyFromForm(HTTPRequestBody $requestBody): ThirdParty
     {

--- a/api/src/Service/ThirdPartyService.php
+++ b/api/src/Service/ThirdPartyService.php
@@ -69,6 +69,12 @@ final class ThirdPartyService
 
         $thirdParty->country = $this->countryService->getCountry($requestBody->getString('pays'));
 
+        $thirdParty->contacts = \array_map(
+            // @phpstan-ignore argument.type
+            fn($contact) => $this->makeThirdPartyContactFromForm($contact),
+            $requestBody->getArray('contacts')
+        );
+
         // Logo
         $logoData = $requestBody->get('logo');
         if (\is_array($logoData) || \is_string($logoData) || null === $logoData) {
@@ -86,6 +92,26 @@ final class ThirdPartyService
      * @param ThirdPartyContactArray $rawData Raw data from the database.
      */
     public function makeThirdPartyContactFromDatabase(array $rawData): ThirdPartyContact
+    {
+        $rawDataAH = new ArrayHandler($rawData);
+
+        $contact = new ThirdPartyContact();
+        $contact->id = $rawDataAH->getInt('id');
+        $contact->name = $rawDataAH->getString('nom');
+        $contact->email = $rawDataAH->getString('email');
+        $contact->phone = $rawDataAH->getString('telephone');
+        $contact->position = $rawDataAH->getString('role');
+        $contact->comments = $rawDataAH->getString('commentaire');
+
+        return $contact;
+    }
+
+    /**
+     * Creates a ThirdPartyContact object from raw data.
+     * 
+     * @param ThirdPartyContactArray $rawData Raw data from the form.
+     */
+    public function makeThirdPartyContactFromForm(array $rawData): ThirdPartyContact
     {
         $rawDataAH = new ArrayHandler($rawData);
 

--- a/api/src/Service/ThirdPartyService.php
+++ b/api/src/Service/ThirdPartyService.php
@@ -43,12 +43,6 @@ final class ThirdPartyService
 
         $thirdParty->country = $this->countryService->getCountry($rawDataAH->getString('pays'));
 
-        $thirdParty->contacts = \array_map(
-            // @phpstan-ignore argument.type
-            fn($contact) => $this->makeThirdPartyContactFromDatabase($contact),
-            $rawDataAH->getArray('contacts')
-        );
-
         // Logo
         $logoData = $rawDataAH->get('logo');
         if (\is_string($logoData) || null === $logoData) {
@@ -120,7 +114,7 @@ final class ThirdPartyService
         $contact->name = $rawDataAH->getString('nom');
         $contact->email = $rawDataAH->getString('email');
         $contact->phone = $rawDataAH->getString('telephone');
-        $contact->position = $rawDataAH->getString('role');
+        $contact->position = $rawDataAH->getString('fonction');
         $contact->comments = $rawDataAH->getString('commentaire');
 
         return $contact;

--- a/api/src/Service/ThirdPartyService.php
+++ b/api/src/Service/ThirdPartyService.php
@@ -94,7 +94,7 @@ final class ThirdPartyService
         $contact->name = $rawDataAH->getString('nom');
         $contact->email = $rawDataAH->getString('email');
         $contact->phone = $rawDataAH->getString('telephone');
-        $contact->position = $rawDataAH->getString('role');
+        $contact->position = $rawDataAH->getString('fonction');
         $contact->comments = $rawDataAH->getString('commentaire');
 
         return $contact;

--- a/api/src/Service/TimberService.php
+++ b/api/src/Service/TimberService.php
@@ -18,7 +18,7 @@ use App\DTO\SupplierWithUniqueDeliveryNoteNumber;
 use App\DTO\TimberRegistryEntryDTO;
 use App\DTO\TimberStatsDTO;
 use App\DTO\TimberTransportSuggestionsDTO;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Entity\Timber\TimberAppointment;
 use App\Entity\Timber\TimberDispatchItem;
 use App\Repository\TimberAppointmentRepository;

--- a/api/tests/Entity/Bulk/BulkAppointmentTest.php
+++ b/api/tests/Entity/Bulk/BulkAppointmentTest.php
@@ -11,7 +11,7 @@ use App\Entity\Bulk\BulkDispatchItem;
 use App\Entity\Bulk\BulkProduct;
 use App\Entity\Bulk\BulkQuality;
 use App\Entity\Stevedoring\StevedoringStaff;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Entity/Bulk/BulkAppointmentValidationTest.php
+++ b/api/tests/Entity/Bulk/BulkAppointmentValidationTest.php
@@ -10,7 +10,7 @@ use App\Core\Exceptions\Client\ValidationException;
 use App\Entity\Bulk\BulkAppointment;
 use App\Entity\Bulk\BulkProduct;
 use App\Entity\Bulk\BulkQuality;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Entity/Chartering/CharterTest.php
+++ b/api/tests/Entity/Chartering/CharterTest.php
@@ -11,7 +11,7 @@ use App\Core\Component\Collection;
 use App\Entity\Chartering\Charter;
 use App\Entity\Chartering\CharterLeg;
 use App\Entity\Port;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Entity/Config/PdfConfigTest.php
+++ b/api/tests/Entity/Config/PdfConfigTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity\Config;
 
 use App\Entity\Config\PdfConfig;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Entity/Config/TimberQuickAppointmentAddTest.php
+++ b/api/tests/Entity/Config/TimberQuickAppointmentAddTest.php
@@ -8,7 +8,7 @@ namespace App\Tests\Entity\Config;
 
 use App\Core\Component\Module;
 use App\Entity\Config\TimberQuickAppointmentAdd;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;

--- a/api/tests/Entity/Shipping/ShippingCallTest.php
+++ b/api/tests/Entity/Shipping/ShippingCallTest.php
@@ -11,7 +11,7 @@ use App\Entity\Port;
 use App\Entity\Shipping\ShippingCall;
 use App\Entity\Shipping\ShippingCallCargo;
 use App\Entity\Stevedoring\ShipReport;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/api/tests/Entity/ThirdParty/ThirdPartyContactTest.php
+++ b/api/tests/Entity/ThirdParty/ThirdPartyContactTest.php
@@ -1,0 +1,42 @@
+<?php
+
+// Path: api/tests/Entity/ThirdParty/ThirdPartyContactTest.php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Entity\ThirdParty\ThirdPartyContact;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ThirdPartyContact::class)]
+final class ThirdPartyContactTest extends TestCase
+{
+    public function testToArray(): void
+    {
+        // Given
+        $contact = new ThirdPartyContact();
+        $contact->id = 1;
+        $contact->name = 'John Doe';
+        $contact->email = 'test@example.com';
+        $contact->phone = '1234567890';
+        $contact->position = 'Manager';
+        $contact->comments = 'Test comment';
+
+        $expected = [
+            'id' => 1,
+            'nom' => 'John Doe',
+            'telephone' => '1234567890',
+            'email' => 'test@example.com',
+            'role' => 'Manager',
+            'commentaire' => 'Test comment',
+        ];
+
+        // When
+        $result = $contact->toArray();
+
+        // Then
+        $this->assertSame($expected, $result);
+    }
+}

--- a/api/tests/Entity/ThirdParty/ThirdPartyContactTest.php
+++ b/api/tests/Entity/ThirdParty/ThirdPartyContactTest.php
@@ -29,7 +29,7 @@ final class ThirdPartyContactTest extends TestCase
             'nom' => 'John Doe',
             'telephone' => '1234567890',
             'email' => 'test@example.com',
-            'role' => 'Manager',
+            'fonction' => 'Manager',
             'commentaire' => 'Test comment',
         ];
 

--- a/api/tests/Entity/ThirdParty/ThirdPartyContactValidationTest.php
+++ b/api/tests/Entity/ThirdParty/ThirdPartyContactValidationTest.php
@@ -1,0 +1,66 @@
+<?php
+
+// Path: api/tests/Entity/ThirdParty/ThirdPartyContactValidationTest.php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity;
+
+use App\Core\Exceptions\Client\ValidationException;
+use App\Entity\ThirdParty\ThirdPartyContact;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ThirdPartyContact::class)]
+final class ThirdPartyContactValidationTest extends TestCase
+{
+    public function testExpectValidationExceptionOnNewContact(): void
+    {
+        // Given
+        $contact = new ThirdPartyContact();
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $contact->validate();
+    }
+
+    public function testNoExceptionOnValidContact(): void
+    {
+        // Given
+        $contact = $this->makeValidContact();
+
+        // When
+        $contact->validate();
+
+        // Then
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testExpectValidationExceptionWhenNameIsEmpty(): void
+    {
+        // Given
+        $contact = $this->makeValidContact();
+        $contact->name = '';
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $contact->validate();
+    }
+
+    private function makeValidContact(): ThirdPartyContact
+    {
+        $contact = new ThirdPartyContact();
+        $contact->id = 1;
+        $contact->name = 'John Doe';
+        $contact->email = 'test@example.com';
+        $contact->phone = '1234567890';
+        $contact->position = 'Manager';
+        $contact->comments = 'Test comment';
+
+        return $contact;
+    }
+}

--- a/api/tests/Entity/ThirdParty/ThirdPartyTest.php
+++ b/api/tests/Entity/ThirdParty/ThirdPartyTest.php
@@ -132,6 +132,7 @@ final class ThirdPartyTest extends TestCase
             'logo' => Environment::getString('LOGOS_URL') . '/filename.webp',
             'actif' => true,
             'nombre_rdv' => 5,
+            'contacts' => [],
         ];
 
         // When

--- a/api/tests/Entity/ThirdParty/ThirdPartyTest.php
+++ b/api/tests/Entity/ThirdParty/ThirdPartyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-// Path: api/tests/Entity/ThirdPartyTest.php
+// Path: api/tests/Entity/ThirdParty/ThirdPartyTest.php
 
 declare(strict_types=1);
 
@@ -8,7 +8,7 @@ namespace App\Tests\Entity;
 
 use App\Core\Array\Environment;
 use App\Entity\Country;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 

--- a/api/tests/Entity/Timber/TimberAppointmentTest.php
+++ b/api/tests/Entity/Timber/TimberAppointmentTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity\Timber;
 
 use App\Entity\Stevedoring\StevedoringStaff;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Entity\Timber\TimberAppointment;
 use App\Entity\Timber\TimberDispatchItem;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/api/tests/Entity/Timber/TimberAppointmentValidationTest.php
+++ b/api/tests/Entity/Timber/TimberAppointmentValidationTest.php
@@ -7,7 +7,7 @@ declare(strict_types=1);
 namespace App\Tests\Entity\Timber;
 
 use App\Core\Exceptions\Client\ValidationException;
-use App\Entity\ThirdParty;
+use App\Entity\ThirdParty\ThirdParty;
 use App\Entity\Timber\TimberAppointment;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\UsesClass;

--- a/html/src/lib/stores/src/flatStores/tiers.ts
+++ b/html/src/lib/stores/src/flatStores/tiers.ts
@@ -32,4 +32,5 @@ export const tiers = createFlatStore<Tiers>("tiers", {
   logo: null,
   actif: true,
   nombre_rdv: 0,
+  contacts: [],
 });

--- a/html/src/pages/tiers/components/index.ts
+++ b/html/src/pages/tiers/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Contacts } from "./src/Contacts.svelte";
+export { default as ContactModal } from "./src/ContactModal.svelte";

--- a/html/src/pages/tiers/components/src/ContactModal.svelte
+++ b/html/src/pages/tiers/components/src/ContactModal.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { Modal, Label, Input } from "flowbite-svelte";
+
+  import { BoutonAction } from "@app/components";
+
+  import { validerFormulaire } from "@app/utils";
+
+  import type { Contact } from "@app/types";
+
+  let form: HTMLFormElement;
+
+  export let open: boolean;
+  export let contacts: Contact[] = [];
+  let originalContact: Contact;
+  export { originalContact as contact };
+
+  let contact: Contact;
+
+  function updateContact() {
+    if (!validerFormulaire(form)) return;
+
+    contact.new = false;
+
+    contacts = contacts.map((c) => (c.id === contact.id ? { ...contact } : c));
+
+    open = false;
+  }
+
+  function cancelUpdate() {
+    if (contact.new) {
+      contacts = contacts.filter((c) => c.id !== contact.id);
+    }
+
+    open = false;
+  }
+</script>
+
+<Modal
+  title="Contact"
+  bind:open
+  dismissable={false}
+  size="lg"
+  on:open={() => (contact = structuredClone(originalContact))}
+>
+  <form class="divide-y" bind:this={form}>
+    <div class="flex flex-col items-center gap-2 py-1 lg:gap-4 lg:py-2">
+      <!-- Nom -->
+      <div class="w-full">
+        <Label for="name">Nom</Label>
+        <Input
+          id="name"
+          name="Nom"
+          bind:value={contact.nom}
+          placeholder="Nom du contact"
+          required
+        />
+      </div>
+
+      <!-- E-mail -->
+      <div class="w-full">
+        <Label for="email">E-mail</Label>
+        <Input
+          type="email"
+          id="email"
+          name="E-mail"
+          placeholder="Adresse e-mail"
+          bind:value={contact.email}
+        />
+      </div>
+
+      <!-- Téléphone -->
+      <div class="w-full">
+        <Label for="phone">Téléphone</Label>
+        <Input
+          type="tel"
+          id="phone"
+          name="Téléphone"
+          bind:value={contact.telephone}
+        />
+      </div>
+
+      <!-- Fonction -->
+      <div class="w-full">
+        <Label for="function">Fonction</Label>
+        <Input
+          id="function"
+          name="Fonction"
+          bind:value={contact.fonction}
+          placeholder="Fonction du contact"
+        />
+      </div>
+
+      <!-- Commentaire -->
+      <div class="w-full">
+        <Label for="comments">Commentaire</Label>
+        <Input
+          id="comments"
+          name="Commentaire"
+          bind:value={contact.commentaire}
+          placeholder="Commentaires"
+        />
+      </div>
+    </div>
+  </form>
+
+  <div class="text-center">
+    <!-- Bouton "Modifier" -->
+    <BoutonAction
+      preset={contact.new ? "ajouter" : "modifier"}
+      on:click={updateContact}
+    />
+
+    <!-- Bouton "Annuler" -->
+    <BoutonAction preset="annuler" on:click={cancelUpdate} />
+  </div>
+</Modal>

--- a/html/src/pages/tiers/components/src/Contacts.svelte
+++ b/html/src/pages/tiers/components/src/Contacts.svelte
@@ -1,0 +1,101 @@
+<!--
+@component
+
+Liste des contacts associés à un tiers.
+
+Usage:
+```tsx
+<Contacts contacts: Contact[] />
+```
+-->
+<script lang="ts">
+  import { PlusIcon } from "lucide-svelte";
+
+  import { LucideButton } from "@app/components";
+
+  import ContactModal from "./ContactModal.svelte";
+
+  import type { Contact } from "@app/types";
+
+  export let contacts: Contact[] = [];
+
+  let modalOpen = false;
+  let contactInModal: Contact | null = null;
+
+  function addContact() {
+    contacts = [
+      ...contacts,
+      {
+        id: Math.random(),
+        nom: "",
+        email: "",
+        telephone: "",
+        fonction: "",
+        commentaire: "",
+        new: true,
+      },
+    ];
+
+    contactInModal = contacts[contacts.length - 1];
+
+    modalOpen = true;
+  }
+
+  function deleteContact(contact: Contact) {
+    contacts = contacts.filter((c) => c !== contact);
+  }
+</script>
+
+<div>
+  <div class="mb-2 text-sm text-gray-500">
+    {contacts.length} contact{contacts.length > 1 ? "s" : ""}
+  </div>
+
+  <ContactModal
+    bind:open={modalOpen}
+    bind:contacts
+    bind:contact={contactInModal}
+  />
+
+  <button on:click|preventDefault={addContact} class="text-sm">
+    Ajouter un contact
+    <i class="icon align-middle" title="Ajouter un contact"
+      ><PlusIcon class="inline" /></i
+    >
+  </button>
+
+  <ul class="pl-5">
+    {#each contacts as contact}
+      <li>
+        {contact.nom}
+
+        {#if contact.fonction}
+          ({contact.fonction})
+        {/if}
+
+        {#if contact.email}
+          - {contact.email}
+        {/if}
+
+        {#if contact.telephone}
+          - {contact.telephone}
+        {/if}
+
+        <LucideButton
+          preset="edit"
+          size="1em"
+          on:click={() => {
+            contactInModal = contact;
+            modalOpen = true;
+          }}
+        />
+
+        <LucideButton
+          preset="delete"
+          size="1em"
+          on:click={() => deleteContact(contact)}
+        />
+      </li>
+    {/each}
+  </ul>
+</div>

--- a/html/src/pages/tiers/index.svelte
+++ b/html/src/pages/tiers/index.svelte
@@ -38,6 +38,8 @@
     SseConnection,
   } from "@app/components";
 
+  import { Contacts } from "./components";
+
   import { tiers } from "@app/stores";
 
   import NO_LOGO_IMAGE from "/src/images/nologo.min.svg";
@@ -192,7 +194,7 @@
   /**
    * Nouveau tiers
    */
-  async function addThirdParty() {
+  async function createThirdParty() {
     if (!validerFormulaire(form)) return;
 
     addButton.$set({ block: true });
@@ -210,13 +212,13 @@
   /**
    * Modifier tiers
    */
-  async function editThirdParty() {
+  async function updateThirdParty() {
     if (!validerFormulaire(form)) return;
 
     editButton.$set({ block: true });
 
     try {
-      await tiers.update(selectedTiers);
+      selectedTiers = await tiers.update(selectedTiers);
 
       Notiflix.Notify.success("Le tiers a été modifié");
     } catch (erreur) {
@@ -411,6 +413,12 @@
       />
     </div>
 
+    <!-- Contacts -->
+    <div class="mb-4">
+      <Label>Contacts</Label>
+      <Contacts bind:contacts={selectedTiers.contacts} />
+    </div>
+
     <!-- Logo -->
     <div class="mb-4">
       <Label for="logo">Logo</Label>
@@ -545,7 +553,7 @@
       <BoutonAction
         preset="ajouter"
         bind:this={addButton}
-        on:click={addThirdParty}
+        on:click={createThirdParty}
       />
     {/if}
 
@@ -554,7 +562,7 @@
       <BoutonAction
         preset="modifier"
         bind:this={editButton}
-        on:click={editThirdParty}
+        on:click={updateThirdParty}
       />
     {/if}
 

--- a/html/types/index.ts
+++ b/html/types/index.ts
@@ -41,5 +41,5 @@ export type {
   StevedoringShipReportFilterData,
 } from "./src/Stevedoring";
 export type { RdvBois, CamionsParDate, TimberFilter } from "./src/Timber";
-export type { Tiers } from "./src/ThirdParty";
+export type { Tiers, Contact } from "./src/ThirdParty";
 export type { CompteUtilisateur } from "./src/UserAccount";

--- a/html/types/src/ThirdParty.ts
+++ b/html/types/src/ThirdParty.ts
@@ -132,4 +132,49 @@ export type Tiers = {
    * Nombre de RDV du tiers.
    */
   nombre_rdv?: number;
+
+  /**
+   * Contacts associés au tiers.
+   */
+  contacts: Contact[];
+};
+
+/**
+ * Contact associé à un tiers.
+ */
+export type Contact = {
+  /**
+   * Identifiant du contact.
+   */
+  id: number;
+
+  /**
+   * Nom du contact.
+   */
+  nom: string;
+
+  /**
+   * Email du contact.
+   */
+  email: string;
+
+  /**
+   * Téléphone du contact.
+   */
+  telephone: string;
+
+  /**
+   * Fonction du contact.
+   */
+  fonction: string;
+
+  /**
+   * Commentaires.
+   */
+  commentaire: string;
+
+  /**
+   * Indique si le contact est nouveau (ajouté dans le modal)
+   */
+  new?: boolean;
 };


### PR DESCRIPTION
Closes #38 

Ajout d'une nouvelle entité `ThirdPartyContact` pour gérer les contacts associés aux tiers.  Implémentation des opérations CRUD pour ces contacts côté back-end.  
Intégration des contacts côté front-end avec l'ajout de nouveaux composants.