### PR TITLE
Affichage d'un message d'erreur explicite pour les doublons de configuration PDF

### DIFF
--- a/api/src/Entity/Config/PdfConfig.php
+++ b/api/src/Entity/Config/PdfConfig.php
@@ -6,9 +6,10 @@ declare(strict_types=1);
 
 namespace App\Entity\Config;
 
-use App\Core\Validation\Constraints\Required;
 use App\Core\Traits\IdentifierTrait;
 use App\Core\Traits\ModuleTrait;
+use App\Core\Validation\Constraints\PositiveOrNullNumber;
+use App\Core\Validation\Constraints\Required;
 use App\Entity\AbstractEntity;
 use App\Entity\ThirdParty\ThirdParty;
 
@@ -48,8 +49,10 @@ final class PdfConfig extends AbstractEntity
         }
     }
 
+    #[PositiveOrNullNumber("Le nombre de jours avant doit être positif ou nul.")]
     public int $daysBefore = 0;
 
+    #[PositiveOrNullNumber("Le nombre de jours après doit être positif ou nul.")]
     public int $daysAfter = 0;
 
     public function getEmailsAsString(): string

--- a/api/src/Repository/PdfConfigRepository.php
+++ b/api/src/Repository/PdfConfigRepository.php
@@ -117,6 +117,14 @@ final class PdfConfigRepository extends Repository
             $lastInsertId = (int) $this->mysql->lastInsertId();
             $this->mysql->commit();
         } catch (\PDOException $e) {
+            if ($this->mysql->inTransaction()) {
+                $this->mysql->rollBack();
+            }
+
+            if ($e->getCode() == 23000) {
+                throw new DBException("Une configuration existe déjà pour {$config->module}/{$config->supplier?->shortName}.", previous: $e);
+            }
+
             throw new DBException("Erreur lors de la création", previous: $e);
         }
 

--- a/api/src/Service/PdfConfigService.php
+++ b/api/src/Service/PdfConfigService.php
@@ -122,6 +122,8 @@ final class PdfConfigService
     {
         $config = $this->makeConfigFromForm($rawData)->setId($id);
 
+        $config->validate();
+
         return $this->pdfConfigRepository->updateConfig($config);
     }
 
@@ -135,6 +137,8 @@ final class PdfConfigService
     public function createConfig(HTTPRequestBody $rawData): PdfConfig
     {
         $config = $this->makeConfigFromForm($rawData);
+
+        $config->validate();
 
         return $this->pdfConfigRepository->createConfig($config);
     }

--- a/api/tests/Entity/Config/PdfConfigTest.php
+++ b/api/tests/Entity/Config/PdfConfigTest.php
@@ -42,6 +42,58 @@ final class PdfConfigTest extends TestCase
         $this->assertTrue($actualAutoSend);
     }
 
+    public function testSetAndGetDaysBefore(): void
+    {
+        // Given
+        $pdfConfig = new PdfConfig();
+        $daysBefore = 10;
+
+        // When
+        $pdfConfig->daysBefore = $daysBefore;
+        $actualDaysBefore = $pdfConfig->daysBefore;
+
+        // Then
+        $this->assertSame($daysBefore, $actualDaysBefore);
+    }
+
+    public function testSetAndGetDaysAfter(): void
+    {
+        // Given
+        $pdfConfig = new PdfConfig();
+        $daysAfter = 7;
+
+        // When
+        $pdfConfig->daysAfter = $daysAfter;
+        $actualDaysAfter = $pdfConfig->daysAfter;
+
+        // Then
+        $this->assertSame($daysAfter, $actualDaysAfter);
+    }
+
+    public function testDaysBeforeDefaultValue(): void
+    {
+        // Given
+        $pdfConfig = new PdfConfig();
+
+        // When
+        $actualDaysBefore = $pdfConfig->daysBefore;
+
+        // Then
+        $this->assertSame(0, $actualDaysBefore);
+    }
+
+    public function testDaysAfterDefaultValue(): void
+    {
+        // Given
+        $pdfConfig = new PdfConfig();
+
+        // When
+        $actualDaysAfter = $pdfConfig->daysAfter;
+
+        // Then
+        $this->assertSame(0, $actualDaysAfter);
+    }
+
     public function testSetAndGetEmailsFromArray(): void
     {
         // Given

--- a/api/tests/Entity/Config/PdfConfigValidationTest.php
+++ b/api/tests/Entity/Config/PdfConfigValidationTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Entity\Config;
+
+use App\Core\Exceptions\Client\ValidationException;
+use App\Entity\Config\PdfConfig;
+use App\Entity\ThirdParty\ThirdParty;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PdfConfig::class)]
+#[UsesClass(ThirdParty::class)]
+final class PdfConfigValidationTest extends TestCase
+{
+    public function testExpectValidationExceptionOnNewConfig(): void
+    {
+        // Given
+        $pdfConfig = new PdfConfig();
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $pdfConfig->validate();
+    }
+
+    public function testNoExceptionOnValidConfig(): void
+    {
+        // Given
+        $pdfConfig = self::makeValidConfig();
+
+        // When
+        $pdfConfig->validate();
+
+        // Then
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testExpectValidationExceptionWhenSupplierIsNull(): void
+    {
+        // Given
+        $pdfConfig = self::makeValidConfig();
+        $pdfConfig->supplier = null;
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $pdfConfig->validate();
+    }
+
+    public function testExpectValidationExceptionWhenDaysBeforeIsNegative(): void
+    {
+        // Given
+        $pdfConfig = self::makeValidConfig();
+        $pdfConfig->daysBefore = -1;
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $pdfConfig->validate();
+    }
+
+    public function testExpectValidationExceptionWhenDaysAfterIsNegative(): void
+    {
+        // Given
+        $pdfConfig = self::makeValidConfig();
+        $pdfConfig->daysAfter = -1;
+
+        // Then
+        $this->expectException(ValidationException::class);
+
+        // When
+        $pdfConfig->validate();
+    }
+
+    private static function makeValidConfig(): PdfConfig
+    {
+        $supplier = new ThirdParty();
+        $supplier->id = 1;
+
+        $pdfConfig = new PdfConfig();
+        $pdfConfig->supplier = $supplier;
+        $pdfConfig->autoSend = false;
+        $pdfConfig->emails = ['test@example.com'];
+        $pdfConfig->daysBefore = 0;
+        $pdfConfig->daysAfter = 0;
+
+        return $pdfConfig;
+    }
+}

--- a/html/src/pages/config/components/src/pdf/LigneConfigPDF.svelte
+++ b/html/src/pages/config/components/src/pdf/LigneConfigPDF.svelte
@@ -254,6 +254,7 @@
           type="number"
           min={0}
           id="days-before"
+          data-nom="Jours avant"
           class="jours_avant"
           bind:value={config.jours_avant}
           required
@@ -267,6 +268,7 @@
           type="number"
           min={0}
           id="days-after"
+          data-nom="Jours après"
           class="jours_apres"
           bind:value={config.jours_apres}
           required


### PR DESCRIPTION
La création ou la modification d'une configuration PDF échoue désormais avec un message d'erreur clair lorsque des doublons sont détectés. Une validation a été ajoutée pour s'assurer que les champs "jours avant" et "jours après" sont positifs ou nuls. Des tests ont été inclus pour vérifier ces validations. Les noms des champs du formulaire ont également été mis à jour pour améliorer l'affichage des erreurs.

Fixes #70