### PR TITLE
Add error logging for PDF email sending failures

### DIFF
--- a/api/src/Service/PdfConfigService.php
+++ b/api/src/Service/PdfConfigService.php
@@ -299,6 +299,12 @@ final class PdfConfigService
 
             return $result;
         } catch (PHPMailerException $e) {
+            \file_put_contents(LOG_DIR . '/pdf_email_errors.log', sprintf(
+                "[%s] Error sending PDF email for config ID %d: %s\n",
+                (new \DateTime())->format('Y-m-d H:i:s'),
+                $configId,
+                $e->getMessage()
+            ), FILE_APPEND);
             throw new ServerException("Erreur d'envoi", previous: $e);
         }
     }


### PR DESCRIPTION
Implement logging for errors encountered while sending PDF emails, capturing the timestamp, config ID, and error message.