### PR TITLE
Correct log file path for email logging

### DIFF
--- a/api/src/Core/Component/Email.php
+++ b/api/src/Core/Component/Email.php
@@ -53,7 +53,7 @@ class Email extends PHPMailer
 
                 $message = $timestamp . PHP_EOL . "debug level $level; message: $str\n";
 
-                $outputFile = '/var/log/phpmailog.log';
+                $outputFile = LOG_DIR . '/phpmailog.log';
                 $fileHandle = fopen($outputFile, 'a');
 
                 if (!$fileHandle) {

--- a/api/src/Service/PdfConfigService.php
+++ b/api/src/Service/PdfConfigService.php
@@ -299,13 +299,6 @@ final class PdfConfigService
 
             return $result;
         } catch (PHPMailerException $e) {
-            \file_put_contents(LOG_DIR . '/pdf_email_errors.log', sprintf(
-                "[%s] Error sending PDF email for config ID %d: %s\nError: %s\n",
-                (new \DateTime())->format('Y-m-d H:i:s'),
-                $configId,
-                $e->getMessage(),
-                $mail->ErrorInfo
-            ), FILE_APPEND);
             throw new ServerException("Erreur d'envoi", previous: $e);
         }
     }


### PR DESCRIPTION
Update the log file path for email logs to use a defined constant, ensuring consistency and easier configuration. Remove redundant error logging for PDF email sending.